### PR TITLE
Fix Undefined Symbol Linker Error

### DIFF
--- a/src/flashops.h
+++ b/src/flashops.h
@@ -5,9 +5,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-inline uint8_t readCodeFlash(uint32_t translated_addr);
-inline void writeCodeFlash(uint32_t translated_addr);
-inline byte readDataflash(unsigned int translated_addr);
+uint8_t readCodeFlash(uint32_t translated_addr);
+void writeCodeFlash(uint32_t translated_addr);
+byte readDataflash(unsigned int translated_addr);
 int8_t writeDataflash(unsigned int translated_addr, byte val);
 int flashtobuf(uint8_t *buf, const char *file_path, ssize_t sz);
 int buftoflash(uint8_t *buf, const char *file_path, ssize_t sz);


### PR DESCRIPTION
Fixes #1

Caused by `inline` in flashops.h