### PR TITLE
Add Usage Text

### DIFF
--- a/src/msemu.c
+++ b/src/msemu.c
@@ -1032,7 +1032,10 @@ int main(int argc, char *argv[])
 			break;
 		  case 'h':
 		  default:
-			printf("Usage\n");
+			printf("Usage: %s [-c <path>] [-d <path>]\n", argv[0]);
+			printf(" -c <path>   | path to codeflash (default: %s)\n", codeflash_path);
+			printf(" -d <path>   | path to dataflash (default: %s)\n", dataflash_path);
+			printf(" -h          | show this usage menu\n");
 			return 1;
 		}
 	}


### PR DESCRIPTION
Usage text was empty.

#### Before
```
nico@nico-debian:~/projects/msemu$ ./src/msemu -h
Usage
```

#### After
```
nico@nico-debian:~/projects/msemu$ ./src/msemu -h
Usage: ./src/msemu [-c <path>] [-d <path>]
 -c <path>   | path to codeflash (default: codeflash.bin)
 -d <path>   | path to dataflash (default: dataflash.bin)
 -h          | show this usage menu
```