### PR TITLE
Fix CF/DF Loading Behavior

### DIFF
--- a/src/flashops.c
+++ b/src/flashops.c
@@ -72,40 +72,35 @@ int8_t writeDataflash(MSHW* ms, unsigned int translated_addr, uint8_t val)
 	return modified;
 }
 
-/* Open flash file from path and pull its contents to memory
- *
+/*
  * XXX: Mostly not complete, still don't know exactly how all of these will
  * work together.
  */
 int flashtobuf(uint8_t *buf, const char *file_path, ssize_t sz)
 {
-	FILE *fd;
+	FILE *fd = 0;
+	int ret = 0;
 
 	fd = fopen(file_path, "rb");
 	if (fd)
 	{
-		//fseek(codeflash_fd, 0, SEEK_END);
-		/* TODO: Add debugout print here */
-		//printf("Loading Codeflash ROM:\n  %s (%ld bytes)\n",
-		//  codeflash_path, ftell(codeflash_fd));
-		//fseek(codeflash_fd, 0, SEEK_SET);
-		fread(buf, sizeof(uint8_t), sz, fd);
+		ret = fread(buf, sizeof(uint8_t), sz, fd);
 		fclose(fd);
-		return 0;
-	} else {
-		/* XXX: Move this outside of this function */
-		printf("Couldn't open flash file: %s\n", file_path);
-		return 1;
 	}
+
+	return ret;
 }
 
 int buftoflash(uint8_t *buf, const char *file_path, ssize_t sz)
 {
-	FILE *fd;
-	int ret;
+	FILE *fd = 0;
+	int ret = 0;
 
 	fd = fopen(file_path, "wb");
-	ret = fwrite(buf, sizeof(uint8_t), sz, fd);
-	fclose(fd);
+	if (fd) {
+		ret = fwrite(buf, sizeof(uint8_t), sz, fd);
+		fclose(fd);
+	}
+
 	return ret;
 }

--- a/src/flashops.h
+++ b/src/flashops.h
@@ -6,6 +6,26 @@
 #include "msemu.h"
 
 int8_t writeDataflash(MSHW* ms, unsigned int translated_addr, uint8_t val);
+
+/**
+ * Reads a file into memory.
+ *
+ * buf       - buffer to load file contents into
+ * file_path - path to file on disk
+ * sz        - number of bytes to read
+ *
+ * Returns number of bytes read.
+ */
 int flashtobuf(uint8_t *buf, const char *file_path, ssize_t sz);
+
+/**
+ * Writes a buffer to file.
+ *
+ * buf       - contents to be written
+ * file_path - path to file on disk
+ * sz        - number of bytes to write
+ *
+ * Returns number of bytes written.
+ */
 int buftoflash(uint8_t *buf, const char *file_path, ssize_t sz);
 #endif


### PR DESCRIPTION
## Background
Fixes #39
Fixes #41 

 * Aborts on CF load fail
 * Creates DF image if it doesn't exist

## Tests
#### Bad codeflash path should abort
```
nico@nico-debian:~/projects/msemu$ ./src/msemu --codeflash badpath
Couldn't open flash file: badpath
Failed to load codeflash at 'badpath'. Aborting.
Aborted
```

#### Dataflash should be created if it doesn't exist
```
nico@nico-debian:~/projects/msemu$ ./src/msemu --dataflash badfile
Codeflash loaded from 'codeflash.bin'.
Existing dataflash image not found at 'badfile'.
Dataflash will be saved to 'badfile' on exit.

Mailstation Emulator v0.2

Press ctrl+c to enter interactive Mailstation debugger
POWER ON
POWER OFF
Writing dataflash buffer to disk
```

#### Good dataflash path should load
```
nico@nico-debian:~/projects/msemu$ ./src/msemu --dataflash mydataflash.bin
Dataflash will be saved to 'mydataflash.bin' on exit.

Mailstation Emulator v0.2

Press ctrl+c to enter interactive Mailstation debugger
```

#### No dataflash path should use default path
```
nico@nico-debian:~/projects/msemu$ ./src/msemu
Dataflash will be saved to 'dataflash.bin' on exit.

Mailstation Emulator v0.2

Press ctrl+c to enter interactive Mailstation debugger
```