### PR TITLE
Refactor MS core and peripherals

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(msemu
 	flashops.c
 	main.c
 	msemu.c
+	io.c
 	ui.c
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(msemu
 	debug.c
 	flashops.c
+	lcd.c
 	main.c
 	msemu.c
 	io.c

--- a/src/debug.c
+++ b/src/debug.c
@@ -7,6 +7,7 @@
 
 #include "debug.h"
 #include "msemu.h"
+#include "io.h"
 
 #include <z80ex/z80ex_dasm.h>
 #include <z80ex/z80ex.h>

--- a/src/debug.c
+++ b/src/debug.c
@@ -246,7 +246,7 @@ int debug_prompt(void)
 
 	while (1) {
 		printf("> ");
-		bzero(&buf, sizeof(buf));
+		memset(&buf, '\0', sizeof(buf));
 		fgets(buf, sizeof(buf), stdin);
 
 		i = NUMCMDS;
@@ -295,7 +295,7 @@ void debug_dasm(void)
 
 	if (!debug_isbreak() && !(dbg_level & LOG_TRACE)) return;
 
-	bzero(&dasm_buffer, dasm_buffer_len);
+	memset(&dasm_buffer, '\0', dasm_buffer_len);
 	z80ex_dasm(
 	  &dasm_buffer[0], dasm_buffer_len,
 	  0,

--- a/src/flashops.c
+++ b/src/flashops.c
@@ -3,10 +3,102 @@
 #include "msemu.h"
 #include "sizes.h"
 
+#include <assert.h>
 #include <ctype.h>
+#include <errno.h>
 #include <time.h>
 #include <stdlib.h>
 #include <string.h>
+
+
+/* Helper functions for loading and saving a file to a buffer.
+ *
+ * Arguments for both are the same, buffer, file path, and size in bytes
+ *
+ * Should return number of bytes read from file, 0 on error
+ */
+static int filetobuf(uint8_t *buf, const char *file_path, ssize_t sz)
+{
+	FILE *fd = 0;
+	int ret = 0;
+
+	fd = fopen(file_path, "rb");
+	if (fd) {
+		ret = fread(buf, sizeof(uint8_t), sz, fd);
+		fclose(fd);
+	}
+
+	return ret;
+}
+
+static int buftofile(uint8_t *buf, const char *file_path, ssize_t sz)
+{
+	FILE *fd = 0;
+	int ret = 0;
+
+	fd = fopen(file_path, "wb");
+	if (fd) {
+		ret = fwrite(buf, sizeof(uint8_t), sz, fd);
+		fclose(fd);
+	}
+
+	return ret;
+}
+
+/****************************************************
+ * Dataflash Functions
+ ***************************************************/
+int df_init(uint8_t **df_buf, ms_opts *options)
+{
+	assert(*df_buf == NULL);
+
+	*df_buf = (uint8_t *)calloc(SZ_512K, sizeof(uint8_t));
+	if (*df_buf == NULL) {
+		printf("Unable to allocate dataflash buffer\n");
+		exit(EXIT_FAILURE);
+	}
+
+        /* Open dataflash and dump it in to a buffer.
+         * The dataflash should be exactly 512 KiB.
+         * Its possible to have a short dump, where the remaining bytes are
+         * assumed to be zero. But it in practice shouldn't happen.
+         * It should never be longer either. If it is, we just pretend like
+         * we didn't notice. This might be unwise behavior.
+         */
+	if (!filetobuf(*df_buf, options->df_path, SZ_512K)) {
+                printf("Existing dataflash image not found at '%s', creating "
+                  "a new dataflah image.\n", options->df_path);
+		return ENOENT;
+	}
+
+	return MS_OK;
+}
+
+int df_deinit(uint8_t **df_buf, ms_opts *options)
+{
+	int ret = MS_OK;
+
+	assert(*df_buf != NULL);
+
+	if (options->df_save_to_disk) {
+		ret = buftofile(*df_buf, options->df_path, SZ_512K);
+		if (ret < SZ_512K) {
+			printf("Failed writing dataflash, only wrote %d\n",
+			  ret);
+			ret = EIO;
+		}
+	}
+	free(*df_buf);
+	*df_buf = NULL;
+
+	return ret;
+};
+
+uint8_t df_read(uint8_t *df_buf, unsigned int absolute_addr)
+{
+	/* XXX: Add hook here for lock/unlock */
+	return *(df_buf + absolute_addr);
+}
 
 /* Interpret commands intended for 28SF040 flash
  *
@@ -16,21 +108,17 @@
  * The read path of the dataflash does not have a command associated with it,
  * therefore this is function is only useful for writing/erasing the DF
  *
- * Software data protection status is _NOT_ implemented by this functions, it
- * seems to not be use by the Mailstation in normal application flow.
+ * Software data protection status is _NOT_ implemented by this function!
  *
- * Returns 1 if the dataflash was actually modified. Otherwise returns 0
- *
+ * Currently just returns MS_OK, could potentially return operational errors,
+ * e.g. Cycle/Command mismatches, unknown/invalid commands, etc.
  * While there are a few different possible errors, they are not indicated
  * as a return value at this time.
- *
- * TODO: Add debugging hook here.
  */
-int df_parse_cmd (ms_ctx* ms, unsigned int translated_addr, uint8_t val)
+int df_write(uint8_t *df_buf, unsigned int absolute_addr, uint8_t val)
 {
 	static uint8_t cycle;
 	static uint8_t cmd;
-	int modified = 0;
 
 	if (!cycle) {
 		switch (val) {
@@ -52,23 +140,23 @@ int df_parse_cmd (ms_ctx* ms, unsigned int translated_addr, uint8_t val)
 		switch(cmd) {
 		  case 0x20: /* Sector erase, execute cmd is 0xD0 */
 			if (val != 0xD0) break;
-			translated_addr &= 0xFFFFFF00;
-			log_debug(" * DF    Sector-Erase: 0x%X\n", translated_addr);
-			memset((uint8_t *)(ms->dev_map[DF] + translated_addr), 0xFF, 0x100);
-			modified = 1;
+			absolute_addr &= 0xFFFFFF00;
+			log_debug(" * DF    Sector-Erase: 0x%X\n", absolute_addr);
+			memset((df_buf + absolute_addr), 0xFF, 0x100);
 			break;
 		  case 0x10: /* Byte program */
-			log_debug(" * DF    W [%04X] <- %02X\n", translated_addr,val);
-			*(uint8_t *)(ms->dev_map[DF] + translated_addr) = val;
-			modified = 1;
+			log_debug(" * DF    W [%04X] <- %02X\n", absolute_addr,val);
+			*(df_buf + absolute_addr) = val;
 			break;
 		  case 0x30: /* Chip erase, execute cmd is 0x30 */
 			if (val != 0x30) break;
 			log_debug(" * DF    Chip erase\n");
-			memset((uint8_t *)ms->dev_map[DF], 0xFF, SZ_512K);
-			modified = 1;
+			memset(df_buf, 0xFF, SZ_512K);
 			break;
 		  case 0x90: /* Read ID */
+			/* XXX: Currently does not do any operation with this
+			 * command. Does not seem to affect MS operation though
+			 */
 			log_debug(" * DF    Read ID\n");
 			break;
 		  default:
@@ -79,94 +167,59 @@ int df_parse_cmd (ms_ctx* ms, unsigned int translated_addr, uint8_t val)
 		cycle = 0;
 	}
 
-	return modified;
+	return MS_OK;
 }
 
-/* Generate and set a random serial number to dataflash buffer that is valid
- * for Mailstation
- *
- * Disassembly of codeflash found that the verification process for serial num
- * is that it starts at 0x7FFC8, is 16 bytes long, each character must be
- * ASCII '0'-'9', 'A'-'Z', 'a'-'z', or '-'
- * In all observed Mailstations, the last character is '-', but it does
- * not seem to be enforced in Mailstation firmware. Nevertheless, the last char
- * is set to a '-'
- */
-void df_set_rnd_serial(ms_ctx *ms)
+
+/****************************************************
+ * Codeflash Functions
+ ***************************************************/
+int cf_init(uint8_t **cf_buf, ms_opts *options)
 {
-	int i;
-	uint8_t rnd;
-	uint8_t *buf;
+	assert(*cf_buf == NULL);
 
-	buf = (uint8_t *)(ms->dev_map[DF] + DF_SN_OFFS);
-
-	srandom((unsigned int)time(NULL));
-	for (i = 0; i < 15; i++) {
-		do {
-			rnd = random();
-		} while (!isalnum(rnd));
-		*buf = rnd;
-		buf++;
+	*cf_buf = (uint8_t *)calloc(SZ_1M, sizeof(uint8_t));
+	if (*cf_buf == NULL) {
+		printf("Unable to allocate codeflash buffer\n");
+		exit(EXIT_FAILURE);
 	}
 
-	*buf = '-';
+        /* Open codeflash and dump it in to a buffer.
+         * The codeflash should be exactly 1 MiB.
+         * Its possible to have a short dump, where the remaining bytes are
+         * assumed to be zero.
+         * It should never be longer either. If it is, we just pretend like
+         * we didn't notice. This might be unwise behavior.
+         */
+	if (!filetobuf(*cf_buf, options->cf_path, SZ_1M)) {
+                log_error("Failed to load codeflash from '%s'.\n", options->cf_path);
+		free(*cf_buf);
+		*cf_buf = NULL;
+                return ENOENT;
+        }
+
+	return MS_OK;
 }
 
-/* Check if serial number in dataflash buffer is valid for Mailstation
- *
- * Returns 1 if number is valid, 0 if invalid.
- *
- * Disassembly of codeflash found that the verification process for serial num
- * is that it starts at 0x7FFC8, is 16 bytes long, each character must be
- * ASCII '0'-'9', 'A'-'Z', 'a'-'z', or '-'
- * In all observed Mailstations, the last character is '-', but it does
- * not seem to be enforced in Mailstation firmware; it is not enforced here
- */
-int df_serial_valid(ms_ctx *ms)
+int cf_deinit(uint8_t **cf_buf, ms_opts *options)
 {
-	int i;
-	int ret = 1;
-	uint8_t *buf;
+	assert(*cf_buf != NULL);
 
-	buf = (uint8_t *)(ms->dev_map[DF] + DF_SN_OFFS);
+	free(*cf_buf);
+	*cf_buf = NULL;
 
-	for (i = 0; i < 16; i++) {
-		if (!isalnum(*buf) && *buf != '-') ret = 0;
-		buf++;
-	}
-
-	return ret;
+	return 0;
 }
 
-/*
- * XXX: Mostly not complete, still don't know exactly how all of these will
- * work together.
- */
-int filetobuf(uint8_t *buf, const char *file_path, ssize_t sz)
+uint8_t cf_read(uint8_t *cf_buf, unsigned int absolute_addr)
 {
-	FILE *fd = 0;
-	int ret = 0;
-
-	fd = fopen(file_path, "rb");
-	if (fd)
-	{
-		ret = fread(buf, sizeof(uint8_t), sz, fd);
-		fclose(fd);
-	}
-
-	return ret;
+	return *(cf_buf + absolute_addr);
 }
 
-int buftofile(uint8_t *buf, const char *file_path, ssize_t sz)
+int cf_write(uint8_t *cf_buf, unsigned int absolute_addr, uint8_t val)
 {
-	FILE *fd = 0;
-	int ret = 0;
+	printf("CF write not implemented!\n");
 
-	fd = fopen(file_path, "wb");
-	if (fd) {
-		ret = fwrite(buf, sizeof(uint8_t), sz, fd);
-		fclose(fd);
-	}
-
-	return ret;
+	return 0;
 }
+

--- a/src/flashops.c
+++ b/src/flashops.c
@@ -10,6 +10,62 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Struct to handle software data protection of the 28SF040
+ * The dataflash starts out locked, so in order to get back to the locked
+ * state, the whole array must be traversed. In msemu, a counter can be
+ * used to watch the reads, once the unlock set is matched, then the device
+ * will remain unlocked until successfully matching the lock set.
+ */
+
+/* The dataflash buffer is used to track this state machine. Its a little
+ * clever so here is how it works:
+ *
+ * 512K+1 byte is allocated for the DF, the +1 is used to track the state
+ *   of the lock/unlock pattern, and if the DF is able to be written
+ * The DF starts out in the locked state
+ * In the state machine, only the least significant 13 bits of address
+ *  matter for advancing to the next state. As quoted in the datasheet:
+ *  "Addresses >A12 are 'dont care'"
+ * Each read of DF, the address is compared to the next address in the
+ *   pattern. If the address matches, then move to the next state.
+ * The pacing of this state machine is such that 0x0 through 0x6 are
+ *   the states to unlock. If 0x7 is reached, the DF is unlocked and
+ *   the state machine is advanced to step 0x8 and will await the
+ *   next states to re-lock the DF.
+ * If at any time, there is an address miss or a DF write, the current
+ *   state is ANDed against ~0x7. This has the effect of clearing the state
+ *   machine to either the base locked or unlocked state; that is either
+ *   0x0 or 0x8
+ * The most significant bit of the tracking byte is used to note the state of
+ *   the software data protect and is evaluated if there is an attempt to write
+ *   to the DF
+ *
+ * Tracking byte:
+ * 8'b0xxxxxxx - Dataflash is locked (default state)
+ * 8'b1xxxxxxx - Dataflash is unlocked
+ * bits 6:4 are unused at this time
+ */
+const uint16_t df_unlock_lock_arr[] = {
+	0x1823,
+	0x1820,
+	0x1822,
+	0x0418,
+	0x041B,
+	0x0419,
+	0x041A,
+
+	0x0000,
+
+	0x1823,
+	0x1820,
+	0x1822,
+	0x0418,
+	0x041B,
+	0x0419,
+	0x040A,
+
+	0x0000
+};
 
 /* Helper functions for loading and saving a file to a buffer.
  *
@@ -52,7 +108,9 @@ int df_init(uint8_t **df_buf, ms_opts *options)
 {
 	assert(*df_buf == NULL);
 
-	*df_buf = (uint8_t *)calloc(SZ_512K, sizeof(uint8_t));
+	/* Allocate 512K+1 and store the state of the writeprotect in the +1
+	 * This should not and does not get written back to disk! */
+	*df_buf = (uint8_t *)calloc(SZ_512K+1, sizeof(uint8_t));
 	if (*df_buf == NULL) {
 		printf("Unable to allocate dataflash buffer\n");
 		exit(EXIT_FAILURE);
@@ -96,7 +154,28 @@ int df_deinit(uint8_t **df_buf, ms_opts *options)
 
 uint8_t df_read(uint8_t *df_buf, unsigned int absolute_addr)
 {
-	/* XXX: Add hook here for lock/unlock */
+	volatile uint8_t *wp_track = (df_buf + SZ_512K);
+
+	/* See top of file for explanation of code protect and tracking it */
+
+	/* If the address matches the next number in the sequence, advance
+	 * to the next state. Setting or clearing the write allow bit in
+	 * the tracking byte as needed */
+	if ((absolute_addr & 0x1FFF) == df_unlock_lock_arr[(*wp_track & 0xF)]) {
+		(*wp_track)++;
+		if ((*wp_track & 0xF) == 0x7) {
+			(*wp_track)++;
+			*wp_track |= 0x80; // Set write allowed bit
+		} else if ((*wp_track & 0xF) == 0xF) {
+			/* Clear write allowed bit and return counter to start
+			 * of unlock state machine */
+			*wp_track = 0;
+		}
+	} else {
+		/* If did not match the next state, clear the sequence track */
+		*wp_track &= ~(0x7);
+	}
+
 	return *(df_buf + absolute_addr);
 }
 
@@ -119,6 +198,11 @@ int df_write(uint8_t *df_buf, unsigned int absolute_addr, uint8_t val)
 {
 	static uint8_t cycle;
 	static uint8_t cmd;
+	volatile uint8_t *wp_track = (df_buf + SZ_512K);
+
+	/* ANY write to DF will break the current software protect state
+	 * machine sequence! */
+	*wp_track &= ~(0x7);
 
 	if (!cycle) {
 		switch (val) {
@@ -140,16 +224,28 @@ int df_write(uint8_t *df_buf, unsigned int absolute_addr, uint8_t val)
 		switch(cmd) {
 		  case 0x20: /* Sector erase, execute cmd is 0xD0 */
 			if (val != 0xD0) break;
+			if (!(*wp_track & 0x80)) {
+				log_error(" * DF    Attempted sector erase while DF locked!\n");
+				break;
+			}
 			absolute_addr &= 0xFFFFFF00;
 			log_debug(" * DF    Sector-Erase: 0x%X\n", absolute_addr);
 			memset((df_buf + absolute_addr), 0xFF, 0x100);
 			break;
 		  case 0x10: /* Byte program */
+			if (!(*wp_track & 0x80)) {
+				log_error(" * DF    Attempted byte program while DF locked!\n");
+				break;
+			}
 			log_debug(" * DF    W [%04X] <- %02X\n", absolute_addr,val);
 			*(df_buf + absolute_addr) = val;
 			break;
 		  case 0x30: /* Chip erase, execute cmd is 0x30 */
 			if (val != 0x30) break;
+			if (!(*wp_track & 0x80)) {
+				log_error(" * DF    Attempted chip erase while DF locked!\n");
+				break;
+			}
 			log_debug(" * DF    Chip erase\n");
 			memset(df_buf, 0xFF, SZ_512K);
 			break;

--- a/src/flashops.h
+++ b/src/flashops.h
@@ -5,54 +5,47 @@
 #include <stdio.h>
 #include "msemu.h"
 
-#define DF_SN_OFFS	0x7FFC8
+/**
+ * Initialize buffer, open file, and copy contents to buffer
+ *
+ * **buf    - Pointer to pointer to buffer to use for flash
+ * *options - Pointer to ms_opts struct w/ file path to open/copy contents from
+ */
+int df_init(uint8_t **df_buf, ms_opts *options);
+int cf_init(uint8_t **cf_buf, ms_opts *options);
+
+/**
+ * Write buffer contents back to file (optionally not write back)
+ *
+ * **buf    - Pointer to point to buffer to use for flash
+ * *options - Pointer to ms_opts struct w/ file path and save to disk opts
+ */
+int df_deinit(uint8_t **df_buf, ms_opts *options);
+int cf_deinit(uint8_t **cf_buf, ms_opts *options);
 
 /**
  * Interpret commands intended for 28SF040 flash, aka Mailstation dataflash
  *
- * ms              - Struct of ms_hw used by main emulation
- * translated_addr - Address in range of dataflash, 0x00000:0x7FFFF
- * val             - Command or value to send to dataflash
+ * *df_buf       - Pointer to buffer for dataflash
+ * absolute_addr - Address in range of dataflash, 0x00000:0x7FFFF
+ * val           - Command or value to send to dataflash
  */
-int df_parse_cmd(ms_ctx* ms, unsigned int translated_addr, uint8_t val);
+int df_write(uint8_t *df_buf, unsigned int absolute_addr, uint8_t val);
 
 /**
- * Generate and set a random serial number in dataflash
+ * Return a byte from the Mailstation dataflash buffer. This does not
+ * require any special command structure unlike the write path.
  *
- * See flashops.c for more detail about the serial number
- *
- * ms - Pointer to ms_ctx which already has dev_map set up and allocated
+ * *buf          - Pointer to buffer for flash
+ * absolute_addr - Address in range of flash:
+ *                 Dataflash 0x00000:0x7FFFF
+ *                 Codeflash 0x00000:0xFFFFF
  */
-void df_set_rnd_serial(ms_ctx *ms);
+uint8_t df_read(uint8_t *df_buf, unsigned int absolute_addr);
+uint8_t cf_read(uint8_t *cf_buf, unsigned int absolute_addr);
 
-/**
- * Check if serial number in dataflash is valid
- *
- * See flashops.c for more detail about the serial number
- *
- * ms - Pointer to ms_ctx which already has dev_map set up and allocated
- */
-int df_serial_valid(ms_ctx *ms);
 
-/**
- * Reads a file into memory.
- *
- * buf       - buffer to load file contents into
- * file_path - path to file on disk
- * sz        - number of bytes to read
- *
- * Returns number of bytes read.
- */
-int filetobuf(uint8_t *buf, const char *file_path, ssize_t sz);
+/* Unimplemented at this time */
+int cf_write(uint8_t *cf_buf, unsigned int absolute_addr, uint8_t val);
 
-/**
- * Writes a buffer to file.
- *
- * buf       - contents to be written
- * file_path - path to file on disk
- * sz        - number of bytes to write
- *
- * Returns number of bytes written.
- */
-int buftofile(uint8_t *buf, const char *file_path, ssize_t sz);
-#endif
+#endif // __FLASHOPS_H__

--- a/src/io.c
+++ b/src/io.c
@@ -1,0 +1,49 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "msemu.h"
+#include "sizes.h"
+
+/* Can be called multiple times, will zero the buffer if *io_buf is not null */
+/* Standard Z80 IO access will use lower 8bit of ADDR to be IO address with
+ * upper 8bit of ADDR being the value to write to the IO port
+ */
+int io_init(uint8_t **io_buf)
+{
+	if (*io_buf == NULL) {
+		*io_buf = (uint8_t *)calloc(SZ_256, sizeof(uint8_t));
+		if (*io_buf == NULL) {
+			printf("Unable to allocate IO buffer\n");
+			exit(EXIT_FAILURE);
+		}
+	} else {
+		/* Buffer is already allocated, just zero it out */
+		memset(*io_buf, '\0', SZ_256);
+	}
+
+	return MS_OK;
+}
+
+int io_deinit(uint8_t **io_buf)
+{
+	assert(*io_buf != NULL);
+	free(*io_buf);
+
+	return MS_OK;
+}
+
+uint8_t io_read(uint8_t *io_buf, unsigned int absolute_addr)
+{
+	assert(io_buf != NULL);
+	return *(io_buf + absolute_addr);
+}
+
+int io_write(uint8_t *io_buf, unsigned int absolute_addr, uint8_t val)
+{
+	assert(io_buf != NULL);
+	*(io_buf + absolute_addr) = val;
+
+	return MS_OK;
+}

--- a/src/io.h
+++ b/src/io.h
@@ -1,0 +1,90 @@
+#ifndef __IO_H__
+#define __IO_H_
+
+#include "msemu.h"
+
+/* List of IO addresses and bit values */
+
+#define KEYBOARD		0x01
+#define KBD_ROLCOL7_BIT		(1 << 7)
+#define KBD_ROLCOL6_BIT		(1 << 6)
+#define KBD_ROLCOL5_BIT		(1 << 5)
+#define KBD_ROLCOL4_BIT		(1 << 4)
+#define KBD_ROLCOL3_BIT		(1 << 3)
+#define KBD_ROLCOL2_BIT		(1 << 2)
+#define KBD_ROLCOL1_BIT		(1 << 1)
+#define KBD_ROLCOL0_BIT		(1 << 0)
+
+#define MISC2			0x02
+#define MISC2_LCD_EN_BIT	(1 << 7)
+#define MISC2_CALLID_DAT_BIT	(1 << 6)
+#define MISC2_MODEM_EN_BITn	(1 << 5)
+#define MISC2_LED_BIT		(1 << 4)
+#define MISC2_LCD_CAS_BIT	(1 << 3)
+#define MISC2_CALLID_RDY_BIT	(1 << 2)
+#define MISC2_KBD_ROW9_BIT	(1 << 1)
+#define MISC2_KBD_ROW8_BIT	(1 << 0)
+
+#define IRQ_MASK		0x03
+#define IRQ_CALLID_BIT		(1 << 7)
+#define IRQ_MODEM_BIT		(1 << 6)
+#define IRQ_RTC_MAYBE_BIT	(1 << 5)
+#define IRQ_INC_TIME16_BIT	(1 << 4)
+#define IRQ_KBD_BIT		(1 << 1)
+
+#define UNKNOWN0x4		0x04
+#define SLOT4_PAGE		0x05
+#define SLOT4_DEV		0x06
+#define SLOT8_PAGE		0x07
+#define SLOT8_DEV		0x08
+#define MISC9			0x09 /* Printer ctrl, pwr ok, pwr btn */
+#define RTC_SEC			0x10 /* BCD, ones place seconds */
+#define RTC_10SEC		0x11 /* BCD, tens place seconds */
+#define RTC_MIN			0x12 /* BCD, ones place minutes */
+#define RTC_10MIN		0x13 /* BCD, tens place minutes */
+#define RTC_HR			0x14 /* BCD, ones place hours */
+#define RTC_10HR		0x15 /* BCD, tens place hours */
+#define RTC_DOW			0x16 /* BCD, day of week */
+#define RTC_DOM			0x17 /* BCD, ones place day of month */
+#define RTC_10DOM		0x18 /* BCD, tens place day of month */
+#define RTC_MON			0x19 /* BCD, ones place month */
+#define RTC_10MON		0x1A /* BCD, tens place month */
+#define RTC_YR			0x1B /* BCD, ones place years since 1980 */
+#define RTC_10YR		0x1C /* BCD, tens place years since 1980 */
+#define RTC_CTRL1		0x1D /* Unknown */
+#define RTC_CTRL2		0x1E /* Unknown */
+#define RTC_CTRL3		0x1F /* Unknown */
+
+#define PRINT_STATUS		0x21 /* Unknown */
+#define PRINT_DDR		0x2C
+#define PRINT_DR		0x2D
+
+#define UNKNOWN0x28		0x28
+
+/**
+ * Initialize/free buffer for IO.
+ * io_init can be called multiple times, will re-zero buffer if prev. allocated
+ *
+ * **buf    - Pointer to pointer to buffer to use for flash
+ */
+int io_init(uint8_t **io_buf);
+int io_deinit(uint8_t **io_buf);
+
+/**
+ * Return a byte from the Mailstation IO buffer.
+ *
+ * *buf          - Pointer to buffer for IO
+ * absolute_addr - Address in range of IO, 0x00:0xFF
+ */
+uint8_t io_read(uint8_t *io_buf, unsigned int absolute_addr);
+
+/**
+ * Write a byte to the Mailstation IO buffer.
+ *
+ * *buf          - Pointer to buffer for IO
+ * absolute_addr - Address in range of IO, 0x00:0xFF
+ * val           - Byte to write
+ */
+int io_write(uint8_t *io_buf, unsigned int absolute_addr, uint8_t val);
+
+#endif // __IO_H__

--- a/src/lcd.c
+++ b/src/lcd.c
@@ -1,0 +1,131 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "debug.h"
+#include "io.h"
+#include "msemu.h"
+#include "ui.h"
+
+// Default screen size
+#define MS_LCD_WIDTH    320
+#define MS_LCD_HEIGHT   240
+
+//----------------------------------------------------------------------------
+//
+//  Emulates writing to Mailstation LCD device
+//
+int lcd_write(uint8_t *onebit, uint32_t *RGBA8888, int *lcd_cas, uint8_t *io_buf, uint16_t newaddr, uint8_t val, int lcdnum)
+{
+	uint8_t *lcd_ptr;
+
+	if (lcdnum == LCD_L) lcd_ptr = onebit;
+	/* XXX: Fix the use of this magic number, replace with a const */
+	else lcd_ptr = &onebit[4800];
+
+	/* XXX: This might need to be reworked to use non-viewable LCD memory */
+	// Wraps memory address if out of bounds
+	if (newaddr >= 240) newaddr %= 240;
+
+	// Check CAS bit on P2
+	if (io_read(io_buf, MISC2) & 8)
+	{
+		log_debug(" * LCD%s W [%04X] <- %02X\n",
+		  lcdnum == LCD_L ? "_L" : "_R", newaddr, val);
+
+		// Write data to currently selected LCD column.
+		// This is just used for reading back LCD contents to the Mailstation quickly.
+		lcd_ptr[newaddr + (*lcd_cas * 240)] = val;
+
+
+		/*
+			Write directly to newer 8-bit lcd_data8 buffer now too.
+			This is what will actually be drawn on the emulator screen now.
+		*/
+
+		// Reverse column # (MS col #0 starts on right side)
+		int x = 19 - *lcd_cas;
+		// Use right half if necessary
+		if (lcdnum == LCD_R) x += 20;
+
+		// Write out all 8 bits to separate bytes, using the current emulated LCD color
+		int n;
+		for (n = 0; n < 8; n++)
+		{
+			int idx = n + (x * 8) + (newaddr * 320);
+			RGBA8888[idx] = ((val >> n) & 1 ? UI_LCD_PIXEL_ON : UI_LCD_PIXEL_OFF);
+		}
+
+	} else {
+		log_debug(" * LCD%s W [ CAS] <- %02X\n",
+		  lcdnum == LCD_L ? "_L" : "_R", newaddr, val);
+
+		// If CAS line is low, set current column instead
+		*lcd_cas = val;
+	}
+
+	return 0;
+}
+
+//----------------------------------------------------------------------------
+//
+//  Emulates reading from Mailstation LCD
+//
+uint8_t lcd_read(uint8_t *onebit, uint32_t *RGBA8888, int *lcd_cas, uint8_t *io_buf, uint16_t newaddr, int lcdnum)
+{
+	uint8_t *lcd_ptr;
+	uint8_t ret;
+
+	if (lcdnum == LCD_L) lcd_ptr = onebit;
+	/* XXX: Fix the use of this magic number, replace with a const */
+	else lcd_ptr = &onebit[4800];
+
+	/* XXX: This might need to be reworked to use non-viewable LCD memory */
+	// Wraps memory address if out of bounds
+	if (newaddr >= 240) newaddr %= 240;
+
+	// Check CAS bit on P2
+	if (io_read(io_buf, MISC2) & 8)
+	{
+		// Return data on currently selected LCD column
+		ret = lcd_ptr[newaddr + (*lcd_cas * 240)];
+	} else {
+		// Not sure what this normally returns when CAS bit low!
+		ret = *lcd_cas;
+	}
+
+	log_debug(" * LCD%s R [%04X] -> %02X\n",
+	  lcdnum == LCD_L ? "_L" : "_R", newaddr, ret);
+
+	return ret;
+}
+
+int lcd_init(uint8_t **onebit, uint32_t **RGBA8888, int *lcd_cas)
+{
+	if (*onebit == NULL) {
+		*onebit = (uint8_t *)calloc(((MS_LCD_WIDTH * MS_LCD_HEIGHT) / 8),
+		  sizeof(uint8_t));
+		if (*onebit == NULL) {
+			printf("Unable to allocate 1-bit LCD buffer\n");
+			exit(EXIT_FAILURE);
+		}
+	} else {
+		memset(*onebit, '\0', (MS_LCD_WIDTH * MS_LCD_HEIGHT) / 8);
+	}
+
+	if (*RGBA8888 == NULL) {
+		*RGBA8888 = (uint32_t *)calloc(  MS_LCD_WIDTH * MS_LCD_HEIGHT,
+		  sizeof(uint32_t));
+		if (*RGBA8888 == NULL) {
+			printf("Unable to allocate RGB LCD buffer\n");
+			exit(EXIT_FAILURE);
+		}
+	} else {
+		memset(*RGBA8888, '\0', (MS_LCD_WIDTH * MS_LCD_HEIGHT) * sizeof(uint32_t));
+	}
+
+	*lcd_cas = 0;
+
+	return MS_OK;
+}

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -1,0 +1,25 @@
+#ifndef __LCD_H__
+#define __LCD_H__
+
+#include <stdint.h>
+#include "msemu.h"
+
+
+//----------------------------------------------------------------------------
+//
+//  Emulates writing to Mailstation LCD device
+//
+void lcd_write(uint8_t *onebit, uint32_t *RGBA8888, int *lcd_cas, uint8_t *io_buf, uint16_t newaddr, uint8_t val, int lcdnum);
+
+//----------------------------------------------------------------------------
+//
+//  Emulates reading from Mailstation LCD
+//
+uint8_t lcd_read(uint8_t *onebit, uint32_t *RGBA8888, int *lcd_cas, uint8_t *io_buf, uint16_t newaddr, int lcdnum);
+
+int lcd_init(uint8_t **onebit, uint32_t **RGBA8888, int *lcd_cas);
+//uint8_t **lcd?
+
+int lcd_deinit(ms_ctx *ms);
+
+#endif // __LCD_H__

--- a/src/main.c
+++ b/src/main.c
@@ -80,7 +80,7 @@ int main(int argc, char** argv)
 	}
 
 	// Init mailstation w/ options
-	bzero(&ms, sizeof(ms));
+	memset(&ms, '\0', sizeof(ms));
 	if (ms_init(&ms, &options) == MS_ERR) return 1;
 	ui_init(ms.lcd_datRGBA8888);
 

--- a/src/msemu.c
+++ b/src/msemu.c
@@ -15,6 +15,7 @@
 #include "sizes.h"
 
 #include <SDL2/SDL.h>
+#include <errno.h>
 #include <z80ex/z80ex.h>
 #include <z80ex/z80ex_dasm.h>
 
@@ -69,6 +70,62 @@ void powerOff(ms_ctx* ms)
 	// clear LCD
 	memset(ms->lcd_datRGBA8888, 0, MS_LCD_WIDTH * MS_LCD_HEIGHT * sizeof(uint32_t));
 	ui_splashscreen_show();
+}
+
+#define DF_SN_OFFS     0x7FFC8
+
+/* Generate and set a random serial number to dataflash buffer that is valid
+ * for Mailstation
+ *
+ * Disassembly of codeflash found that the verification process for serial num
+ * is that it starts at 0x7FFC8, is 16 bytes long, each character must be
+ * ASCII '0'-'9', 'A'-'Z', 'a'-'z', or '-'
+ * In all observed Mailstations, the last character is '-', but it does
+ * not seem to be enforced in Mailstation firmware. Nevertheless, the last char
+ * is set to a '-'
+ */
+static void ms_set_df_rnd_serial(uint8_t *df_buf)
+{
+	int i;
+	uint8_t rnd;
+
+	df_buf += DF_SN_OFFS;
+
+	srandom((unsigned int)time(NULL));
+	for (i = 0; i < 15; i++) {
+		do {
+			rnd = random();
+		} while (!isalnum(rnd));
+		*df_buf = rnd;
+		df_buf++;
+	}
+
+	*df_buf = '-';
+}
+
+/* Check if serial number in dataflash buffer is valid for Mailstation
+ *
+ * Returns 1 if number is valid, 0 if invalid.
+ *
+ * Disassembly of codeflash found that the verification process for serial num
+ * is that it starts at 0x7FFC8, is 16 bytes long, each character must be
+ * ASCII '0'-'9', 'A'-'Z', 'a'-'z', or '-'
+ * In all observed Mailstations, the last character is '-', but it does
+ * not seem to be enforced in Mailstation firmware; it is not enforced here
+ */
+static int ms_serial_valid(uint8_t *df_buf)
+{
+	int i;
+	int ret = MS_OK;
+
+	df_buf += DF_SN_OFFS;
+
+	for (i = 0; i < 16; i++) {
+		if (!isalnum(*df_buf) && *df_buf != '-') ret = MS_ERR;
+		df_buf++;
+	}
+
+	return ret;
 }
 
 //----------------------------------------------------------------------------
@@ -177,7 +234,7 @@ Z80EX_BYTE z80ex_mread(
 	Z80EX_BYTE ret;
 	ms_ctx* ms = (ms_ctx*)user_data;
 	int slot = ((addr & 0xC000) >> 14);
-	int dev = 0xFF;
+	int dev, page;
 
 	debug_testbp(bpMR, addr);
 
@@ -194,16 +251,20 @@ Z80EX_BYTE z80ex_mread(
 	switch (slot) {
 	  case 0:
 		dev = CF;
+		page = 0;
 		break;
 	  /* TODO: Add page range check */
 	  case 1:
 		dev = (ms->io[SLOT4_DEV] & 0x0F);
+		page = ms->io[SLOT4_PAGE];
 		break;
 	  case 2:
 		dev = (ms->io[SLOT8_DEV] & 0x0F);
+		page = ms->io[SLOT4_PAGE];
 		break;
 	  case 3:
 		dev = RAM;
+		page = 0;
 		break;
 	}
 
@@ -227,7 +288,11 @@ Z80EX_BYTE z80ex_mread(
 		break;
 
 	  case CF:
+		ret = cf_read(ms->cf, ((addr & ~0xC000) + (0x4000 * page)));
+		break;
 	  case DF:
+		ret = df_read(ms->df, ((addr & ~0xC000) + (0x4000 * page)));
+		break;
 	  case RAM:
 		ret = *(uint8_t *)(ms->slot_map[slot] + (addr & 0x3FFF));
 		log_debug(" * MEM   R [%04X] -> %02X\n", addr, ret);
@@ -304,9 +369,9 @@ void z80ex_mwrite(
 	  case LCD_R:
 		writeLCD(ms, (addr - (slot << 14)), val, dev);
 		break;
+
 	  case DF:
-		ms->dataflash_updated = df_parse_cmd(ms,
-		  ((addr - (slot << 14)) + (0x4000 * page)), val);
+		df_write(ms->df, ((addr & ~0xC000) + (0x4000 * page)), val);
 		break;
 
 	  case MODEM:
@@ -319,6 +384,7 @@ void z80ex_mwrite(
 		break;
 
 	  case CF:
+		//cf_write(ms->cf, ((addr & ~0xC000) + (0x4000 * page)), val);
 		log_error(" * CF    W [%04X] INVALID, CANNOT W TO CF @ %04X\n",
 		  addr, z80ex_get_reg(ms->z80, regPC));
 		break;
@@ -652,27 +718,12 @@ int ms_init(ms_ctx* ms, ms_opts* options)
 	 *
 	 * TODO: Add error checking on the buffer allocation
 	 */
-	ms->dev_map[CF] = (uintptr_t)calloc(SZ_1M, sizeof(uint8_t));
-	ms->dev_map[DF] = (uintptr_t)calloc(SZ_512K, sizeof(uint8_t));
-	ms->dev_map[RAM] = (uintptr_t)calloc(SZ_128K, sizeof(uint8_t));
-	ms->io = (uint8_t *)calloc(SZ_64K, sizeof(uint8_t));
-	ms->lcd_dat1bit = (uint8_t *)calloc(((MS_LCD_WIDTH * MS_LCD_HEIGHT) / 8),
-	  sizeof(uint8_t));
-	/* XXX: MAGIC NUMBEERRRR */
-	/* ms->dev_map[LCD_R] = ms->dev_map[LCD_L] + 4800; */
-	ms->lcd_datRGBA8888 = (uint32_t *)calloc(  MS_LCD_WIDTH * MS_LCD_HEIGHT,
-	  sizeof(uint32_t));
 
-	/* Initialize flags. */
-	ms->lcd_lastupdate = 0;
-	ms->lcd_cas = 0;
-	ms->dataflash_updated = 0;
 	ms->interrupt_mask = 0;
 	ms->power_button = 0;
 	ms->power_state = MS_POWERSTATE_OFF;
 
 	/* Initialize the slot_map */
-	ms->slot_map[0] = ms->dev_map[CF]; /* slot0000 is always CF_0 */
 	ms->slot_map[1] = ms->dev_map[((ms->io[SLOT4_DEV]) & 0x0F)] +
 	  (ms->io[SLOT4_PAGE] * 0x4000);
 	ms->slot_map[2] = ms->dev_map[((ms->io[SLOT8_DEV]) & 0x0F)] +
@@ -690,43 +741,19 @@ int ms_init(ms_ctx* ms, ms_opts* options)
 		z80ex_intread, (void*)ms
 	);
 
-	/* Open codeflash and dump it in to a buffer.
-	 * The codeflash should be exactly 1 MiB.
-	 * Its possible to have a short dump, where the remaining bytes are
-	 * assumed to be zero.
-	 * It should never be longer either. If it is, we just pretend like
-	 * we didn't notice. This might be unwise behavior.
-	 */
-	if (!filetobuf((uint8_t *)ms->dev_map[CF], options->cf_path, SZ_1M)) {
-		log_error("Failed to load codeflash at '%s'. Aborting.\n", options->cf_path);
-		return MS_ERR;
+	if (cf_init(&ms->cf, options) == ENOENT) return MS_ERR;
+	/* XXX: Handle return value here. e.g. new disk, invalid disk, etc. */
+
+	/* If opening a new, blank, DF buffer, then assign it a random MS
+	 * compatible serial number.
+	 * If the DF file opened has an invalid serial number, just complain
+	 * loudly with a warning. */
+	if (df_init(&ms->df, options) == ENOENT) {
+		ms_set_df_rnd_serial(ms->df);
 	}
-	printf("Codeflash loaded from '%s'.\n", options->cf_path);
-
-	/* Open dataflash and dump it in to a buffer.
-	 * The dataflash should be exactly 512 KiB.
-	 * Its possible to have a short dump, where the remaining bytes are
-	 * assumed to be zero. But it in practice shouldn't happen.
-	 * It should never be longer either. If it is, we just pretend like
-	 * we didn't notice. This might be unwise behavior.
-	 */
-	/* If dataflash file does not exist, create random serial number
-	 * If dataflash file does exist, check that the serial number is valid.
-	 *   If it is not a valid serial number, error out because some unknown
-	 *   binary was passed as the dataflash.
-	 */
-	if (!filetobuf((uint8_t *)ms->dev_map[DF], options->df_path, SZ_512K)) {
-
-		printf("Existing dataflash image not found at '%s', creating "
-		  "a new dataflah image.\n", options->df_path);
-		df_set_rnd_serial(ms);
-	} else {
-		if (!df_serial_valid(ms)) {
-			log_error("Binary file '%s', may not be a valid "
-			  "dataflash image (contains invalid serial number)!\n",
-			  options->df_path);
-			return MS_ERR;
-		}
+	if (ms_serial_valid(ms->df)) {
+		printf("WARNING! Dataflash does not have valid serial num!\n");
+		printf("This may not be a dataflash image!\n\n");
 	}
 
 	/* Set up debug hooks */
@@ -735,6 +762,14 @@ int ms_init(ms_ctx* ms, ms_opts* options)
 	printf("\nPress ctrl+c to enter interactive Mailstation debugger\n");
 
 	return MS_OK;
+}
+
+int ms_deinit(ms_ctx *ms, ms_opts *options)
+{
+	cf_deinit(&ms->cf, options);
+	df_deinit(&ms->df, options);
+
+	return 0;
 }
 
 int ms_run(ms_ctx* ms)

--- a/src/msemu.c
+++ b/src/msemu.c
@@ -19,24 +19,6 @@
 #include <z80ex/z80ex.h>
 #include <z80ex/z80ex_dasm.h>
 
-// Default entry of color palette to draw Mailstation LCD with
-uint8_t LCD_fg_color = 3;  // LCD black
-uint8_t LCD_bg_color = 2;  // LCD green
-
-// This table translates PC scancodes to the Mailstation key matrix
-int32_t keyTranslateTable[10][8] = {
-	{ SDLK_HOME, SDLK_END, SDLK_INSERT, SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5 },
-	{ 0, 0, 0, SDLK_F6, SDLK_F7, SDLK_F8, SDLK_F9, SDLK_PAGEUP },
-	{ SDLK_BACKQUOTE, SDLK_1, SDLK_2, SDLK_3, SDLK_4, SDLK_5, SDLK_6, SDLK_7 },
-	{ SDLK_8, SDLK_9, SDLK_0, SDLK_MINUS, SDLK_EQUALS, SDLK_BACKSPACE, SDLK_BACKSLASH, SDLK_PAGEDOWN },
-	{ SDLK_TAB, SDLK_q, SDLK_w, SDLK_e, SDLK_r, SDLK_t, SDLK_y, SDLK_u },
-	{ SDLK_i, SDLK_o, SDLK_p, SDLK_LEFTBRACKET, SDLK_RIGHTBRACKET, SDLK_SEMICOLON, SDLK_QUOTE, SDLK_RETURN },
-	{ SDLK_CAPSLOCK, SDLK_a, SDLK_s, SDLK_d, SDLK_f, SDLK_g, SDLK_h, SDLK_j },
-	{ SDLK_k, SDLK_l, SDLK_COMMA, SDLK_PERIOD, SDLK_SLASH, SDLK_UP, SDLK_DOWN, SDLK_RIGHT },
-	{ SDLK_LSHIFT, SDLK_z, SDLK_x, SDLK_c, SDLK_v, SDLK_b, SDLK_n, SDLK_m },
-	{ SDLK_LCTRL, 0, 0, SDLK_SPACE, 0, 0, SDLK_RSHIFT, SDLK_LEFT }
-};
-
 const char* const ms_dev_map_text[] = {
 	"CF",
 	"RAM",
@@ -61,9 +43,26 @@ unsigned char hex2bcd (unsigned char x)
 
 //----------------------------------------------------------------------------
 //
+//  Resets Mailstation state
+//
+void ms_power_on_reset(ms_ctx *ms)
+{
+	/* XXX: Should this re-load CF/DF? */
+	memset(ms->lcd_datRGBA8888, 0, 320*240 * sizeof(*ms->lcd_datRGBA8888));
+	memset(ms->io, 0, 64 * 1024);
+	// XXX: Mailstation normally retains RAM I believe.  But Mailstation OS
+	// won't warm-boot properly if we don't erase!  Not sure why yet.
+	memset((uint8_t *)ms->dev_map[RAM], 0, 128 * 1024);
+	ms->power_state = MS_POWERSTATE_ON;
+	ms->interrupt_mask = 0;
+	z80ex_reset(ms->z80);
+}
+
+//----------------------------------------------------------------------------
+//
 //  Disables emulation, displays opening screen
 //
-void powerOff(ms_ctx* ms)
+void ms_power_off(ms_ctx* ms)
 {
 	ms->power_state = MS_POWERSTATE_OFF;
 
@@ -591,7 +590,7 @@ void z80ex_pwrite (
 	  case UNKNOWN0x28:
 		if (val & 1) {
 			printf("POWER OFF\n");
-			powerOff(ms);
+			ms_power_off(ms);
 		}
 		ms->io[port] = val;
 		break;
@@ -605,38 +604,6 @@ void z80ex_pwrite (
 }
 
 
-
-/* Translate real input keys to MS keyboard matrix
- *
- * The lookup matrix is currently [10][8], we just walk the whole thing like
- * one long buffer and do the math later to figure out exactly what bit was
- * pressed.
- *
- * TODO: Would it make sense to rework keyTranslateTable to a single buffer
- * anyway? Right now the declaration looks crowded and would need some rework
- * already.
- */
-void generateKeyboardMatrix(ms_ctx* ms, int scancode, int eventtype)
-{
-	uint32_t i = 0;
-	int32_t *keytbl_ptr = &keyTranslateTable[0][0];
-
-	for (i = 0; i < (sizeof(keyTranslateTable)/sizeof(int32_t)); i++) {
-		if (scancode == *(keytbl_ptr + i)) {
-			/* Couldn't avoid the magic numbers below. As noted,
-			 * kTT array is [10][8], directly mapping the MS matrix
-			 * of 10 bytes to represent the whole keyboard. Divide
-			 * by 8 to get the uint8_t the scancode falls in, and mod
-			 * 8 to get the bit in that uint8_t that matches the code.
-			 */
-			if (eventtype == SDL_KEYDOWN) {
-				ms->key_matrix[i/8] &= ~((uint8_t)1 << (i%8));
-			} else {
-				ms->key_matrix[i/8] |= ((uint8_t)1 << (i%8));
-			}
-		}
-	}
-}
 
 /* z80ex emulation requires that intread callback be defined. Used for IM 2.
  * Under normal execution, IM 2 is not used, however, some of the hacks used
@@ -688,22 +655,6 @@ int process_interrupts (ms_ctx* ms)
 
 	// Otherwise ignore this
 	return 0;
-}
-
-//----------------------------------------------------------------------------
-//
-//  Resets Mailstation state
-//
-void resetMailstation(ms_ctx* ms)
-{
-	memset(ms->lcd_datRGBA8888, 0, 320*240 * sizeof(*ms->lcd_datRGBA8888));
-	memset(ms->io, 0, 64 * 1024);
-	// XXX: Mailstation normally retains RAM I believe.  But Mailstation OS
-	// won't warm-boot properly if we don't erase!  Not sure why yet.
-	memset((uint8_t *)ms->dev_map[RAM], 0, 128 * 1024);
-	ms->power_state = MS_POWERSTATE_ON;
-	ms->interrupt_mask = 0;
-	z80ex_reset(ms->z80);
 }
 
 int ms_init(ms_ctx* ms, ms_opts* options)
@@ -784,7 +735,6 @@ int ms_run(ms_ctx* ms)
 	int exitemu = 0;
 	uint32_t lasttick = SDL_GetTicks();
 	uint32_t currenttick;
-	SDL_Event event;
 
 	/* NOTE:
 	 * The z80ex library can hook in to RETI opcodes. Allowing us to exec
@@ -793,18 +743,14 @@ int ms_run(ms_ctx* ms)
 	 */
 
 	// Display startup message
-	powerOff(ms);
+	ms_power_off(ms);
 
 	lasttick = SDL_GetTicks();
 
 	while (!exitemu)
 	{
 		if (debug_isbreak()) {
-			switch (debug_prompt()) {
-			  case -1: /* Quit */
-				exitemu = 1;
-				break;
-			}
+			if (debug_prompt() == -1) break;
 		}
 
 		/* XXX: Can replace with SDL_TICKS_PASSED with new
@@ -859,71 +805,9 @@ int ms_run(ms_ctx* ms)
 
 		}
 
-		/* Update LCD if modified (at 20ms rate) */
-		/* TODO: Check over this whole process logic */
-		/* NOTE: Cursory glance suggests the screen updates 20ms after
-		 * the screen array changed.
-		 */
-		if (ms->power_state == MS_POWERSTATE_ON && (ms->lcd_lastupdate != 0) &&
-		  (currenttick - ms->lcd_lastupdate >= 20)) {
-			ui_update_lcd();
-			ms->lcd_lastupdate = 0;
-		}
+		ui_update_lcd();
 
-		/* XXX: All of this needs to be reworked to be far more
-		 * efficient.
-		 */
-		// Check SDL events
-		while (SDL_PollEvent(&event))
-		{
-			/* Exit if SDL quits, or Escape key was pushed */
-			if ((event.type == SDL_QUIT) ||
-			  ((event.type == SDL_KEYDOWN) &&
-				(event.key.keysym.sym == SDLK_ESCAPE))) {
-				exitemu = 1;
-			}
-
-			/* Emulate power button with F12 key */
-			if (event.key.keysym.sym == SDLK_F12)
-			{
-				if (event.type == SDL_KEYDOWN)
-				{
-					ms->power_button = 1;
-					if (ms->power_state == MS_POWERSTATE_OFF)
-					{
-						printf("POWER ON\n");
-						ui_splashscreen_hide();
-						resetMailstation(ms);
-					}
-				} else {
-					ms->power_button = 0;
-				}
-			}
-
-			/* Handle other input events */
-			if ((event.type == SDL_KEYDOWN) ||
-			  (event.type == SDL_KEYUP)) {
-				/* Keys pressed whie right ctrl is held */
-				if (event.key.keysym.mod & KMOD_RCTRL)
-				{
-					if (event.type == SDL_KEYDOWN)
-					{
-						switch (event.key.keysym.sym) {
-						  /* Reset whole system */
-						  case SDLK_r:
-							if (ms->power_state == MS_POWERSTATE_ON)
-							  resetMailstation(ms);
-							break;
-						  default:
-							break;
-						}
-					}
-				} else {
-					/* Proces the key for the MS */
-					generateKeyboardMatrix(ms, event.key.keysym.sym, event.type);
-				}
-			}
-		}
+		if (ui_kbd_process(ms)) break;
 
 		ui_render();
 

--- a/src/msemu.c
+++ b/src/msemu.c
@@ -54,7 +54,7 @@ int ram_init(uint8_t **ram_buf)
 		}
 	} else {
 		/* Buffer is already allocated, just zero it out */
-		bzero(*ram_buf, SZ_128K);
+		memset(*ram_buf, '\0', SZ_128K);
 	}
 
 	return 0;

--- a/src/msemu.h
+++ b/src/msemu.h
@@ -141,4 +141,6 @@ int ms_deinit(ms_ctx* ms, ms_opts* options);
  */
 int ms_run(ms_ctx* ms);
 
+void ms_power_on_reset(ms_ctx *ms);
+
 #endif // __MSEMU_H_

--- a/src/msemu.h
+++ b/src/msemu.h
@@ -83,6 +83,8 @@ typedef struct ms_hw {
 	uintptr_t slot_map[4];
 
 	uint8_t *io;
+	uint8_t *df;
+	uint8_t *cf;
 	uintptr_t dev_map[DEV_CNT];
 
 	uint32_t *lcd_datRGBA8888;
@@ -99,10 +101,6 @@ typedef struct ms_hw {
 	// Bits specify which interrupts have been triggered (returned on P3)
 	uint8_t interrupt_mask;
 
-	// Signals if the dataflash contents have been changed.
-	// Should be cleared once dataflash is written back to disk.
-	uint8_t dataflash_updated;
-
 	uint8_t key_matrix[10];
 
 	// Holds power button status (returned in P9.4)
@@ -118,6 +116,9 @@ typedef struct ms_opts {
 
 	// Dataflash path
 	char* df_path;
+
+	// Save dataflash back to disk
+	int df_save_to_disk;
 } ms_opts;
 
 /**
@@ -129,6 +130,7 @@ typedef struct ms_opts {
  * Returns `MS_OK` on success, error code on failure
  */
 int ms_init(ms_ctx* ms, ms_opts* options);
+int ms_deinit(ms_ctx* ms, ms_opts* options);
 
 /**
  * Runs the mailstation emulation

--- a/src/msemu.h
+++ b/src/msemu.h
@@ -85,6 +85,7 @@ typedef struct ms_hw {
 	uint8_t *io;
 	uint8_t *df;
 	uint8_t *cf;
+	uint8_t *ram;
 	uintptr_t dev_map[DEV_CNT];
 
 	uint32_t *lcd_datRGBA8888;

--- a/src/msemu.h
+++ b/src/msemu.h
@@ -30,53 +30,6 @@ enum ms_dev_map {
 	DEV_CNT,
 };
 
-enum ms_port_map {
-	KEYBOARD	= 0x01,
-	MISC2		= 0x02,
-		/*	p3.7 = Caller id handler
-			p3.5 = maybe rtc???
-			p3.6 = Modem handler
-			p3.4 = increment time16
-			p3.3 = null
-			p3.0 = null
-			p3.1 = Keyboard handler
-			p3.2 = null
-		*/
-	IRQ_MASK	= 0x03,
-	UNKNOWN0x4	= 0x04,
-	SLOT4_PAGE	= 0x05,
-	SLOT4_DEV	= 0x06,
-	SLOT8_PAGE	= 0x07,
-	SLOT8_DEV	= 0x08,
-	MISC9		= 0x09, /* Printer ctrl, pwr ok, pwr btn */
-	RTC_SEC		= 0x10, /* BCD, ones place seconds */
-	RTC_10SEC	= 0x11, /* BCD, tens place seconds */
-	RTC_MIN		= 0x12, /* BCD, ones place minutes */
-	RTC_10MIN	= 0x13, /* BCD, tens place minutes */
-	RTC_HR		= 0x14, /* BCD, ones place hours */
-	RTC_10HR	= 0x15, /* BCD, tens place hours */
-	RTC_DOW		= 0x16, /* BCD, day of week */
-	RTC_DOM		= 0x17, /* BCD, ones place day of month */
-	RTC_10DOM	= 0x18, /* BCD, tens place day of month */
-	RTC_MON		= 0x19, /* BCD, ones place month */
-	RTC_10MON	= 0x1A, /* BCD, tens place month */
-	RTC_YR		= 0x1B, /* BCD, ones place years since 1980 */
-	RTC_10YR	= 0x1C, /* BCD, tens place years since 1980 */
-	RTC_CTRL1	= 0x1D, /* Unknown */
-	RTC_CTRL2	= 0x1E, /* Unknown */
-	RTC_CTRL3	= 0x1F, /* Unknown */
-
-	PRINT_STATUS	= 0x21, /* Unknown */
-	PRINT_DDR	= 0x2C,
-	PRINT_DR	= 0x2D,
-
-	UNKNOWN0x28	= 0x28,
-
-	PORT_CNT	= 0x10000, /* XXX: Currently 64 KiB is used, not sure
-				    * what the actual needed amount is.
-				    */
-};
-
 typedef struct ms_hw {
 	Z80EX_CONTEXT* z80;
 

--- a/src/msemu.h
+++ b/src/msemu.h
@@ -7,10 +7,6 @@
 #define MS_OK    0
 #define MS_ERR   1
 
-// Default screen size
-#define MS_LCD_WIDTH 	320
-#define MS_LCD_HEIGHT	240
-
 // Power state constants
 #define MS_POWERSTATE_ON  1
 #define MS_POWERSTATE_OFF 0
@@ -46,7 +42,7 @@ typedef struct ms_hw {
 	uint8_t *lcd_dat1bit;
 
 	// Stores current LCD column.
-	uint8_t lcd_cas;
+	int lcd_cas;
 
 	// timestamp of last lcd draw, used to decide
 	// whether the lcd should be redrawn.

--- a/src/ui.h
+++ b/src/ui.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#include "msemu.h"
+
 // RGBA8888 colors
 #define UI_COLOR_DIM_GREEN (0x9de08c00)
 #define UI_COLOR_DARK_GREY (0x26211400)
@@ -11,6 +13,8 @@
 // These are the colors used for the LCD screen
 #define UI_LCD_PIXEL_ON  UI_COLOR_DARK_GREY
 #define UI_LCD_PIXEL_OFF UI_COLOR_DIM_GREEN
+
+int ui_kbd_process(ms_ctx *ms);
 
 /**
  * Initializes the user interface.


### PR DESCRIPTION
Per CaptainNic, a lot of the code is pretty ass and pretty intermixed. While I'm proud of the mapping setup with slots, the array that basically mapped the whole 64k address space, etc. it basically became an intermingled and fragile mess.

This is a refactor of the MS core and peripherals, hopefully giving each of them an init, deinit, read, and write function. Should help make some of the code a little less weird and fragile.

This PR is just to help keep track of things and discuss. All of these loose commits will be consolidated logically before actually finalizing.